### PR TITLE
remove broken docker dsl, replace with caveat and sample command usin…

### DIFF
--- a/packs/python-microservice/Jenkinsfile
+++ b/packs/python-microservice/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
             VERSION = readFile('VERSION').trim()
             repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$VERSION"
             // add your env vars as needed with --env-file or -e
-            sh "docker run --rm -t $repo make test"
+            sh "docker run -e PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL $repo make test"
           }
         }
       }

--- a/packs/python-microservice/Jenkinsfile
+++ b/packs/python-microservice/Jenkinsfile
@@ -44,12 +44,10 @@ pipeline {
       steps {
         container('python') {
           script {
-            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:${readFile 'PREVIEW_VERSION'}".trim()
-            docker
-              .image(repo)
-              .inside {
-                sh "make test"
-            }
+            PREVIEW_VERSION = readFile('PREVIEW_VERSION').trim()
+            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            // add your env vars as needed with --env-file or -e
+            sh "docker run --rm -t $repo make test"
           }
         }
       }
@@ -62,7 +60,7 @@ pipeline {
         dir('./charts/preview') {
           container('python') {
             script {
-              PREVIEW_VERSION = readFile "../../PREVIEW_VERSION"
+              PREVIEW_VERSION = readFile("$WORKSPACE/PREVIEW_VERSION").trim()
 
               // create preview namespace if it doesn't exist
               preview_namespace_exists = sh(returnStatus: true, script: "kubectl get namespaces | grep '^$PREVIEW_NAMESPACE[[:space:]]'")
@@ -107,7 +105,7 @@ pipeline {
         }
         container('python') {
           script {
-            VERSION = readFile 'VERSION'
+            VERSION = readFile('VERSION').trim()
             sh """
             export VERSION=$VERSION
             skaffold build -f skaffold.yaml -p prod
@@ -124,12 +122,10 @@ pipeline {
       steps {
         container('python') {
           script {
-            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:${readFile 'VERSION'}".trim()
-            docker
-              .image(repo)
-              .inside {
-                sh "make test"
-            }
+            VERSION = readFile('VERSION').trim()
+            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$VERSION"
+            // add your env vars as needed with --env-file or -e
+            sh "docker run --rm -t $repo make test"
           }
         }
       }

--- a/packs/python-microservice/Jenkinsfile
+++ b/packs/python-microservice/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             PREVIEW_VERSION = readFile('PREVIEW_VERSION').trim()
             repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
             // add your env vars as needed with --env-file or -e
-            sh "docker run --rm -t $repo make test"
+            sh "docker run -e PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL $repo make test"
           }
         }
       }

--- a/packs/python-model-microservice/Jenkinsfile
+++ b/packs/python-model-microservice/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
             VERSION = readFile('VERSION').trim()
             repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$VERSION"
             // add your env vars as needed with --env-file or -e
-            sh "docker run --rm -t $repo make test"
+            sh "docker run -e PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL $repo make test"
           }
         }
       }

--- a/packs/python-model-microservice/Jenkinsfile
+++ b/packs/python-model-microservice/Jenkinsfile
@@ -44,12 +44,10 @@ pipeline {
       steps {
         container('python') {
           script {
-            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:${readFile 'PREVIEW_VERSION'}".trim()
-            docker
-              .image(repo)
-              .inside {
-                sh "make test"
-            }
+            PREVIEW_VERSION = readFile('PREVIEW_VERSION').trim()
+            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            // add your env vars as needed with --env-file or -e
+            sh "docker run --rm -t $repo make test"
           }
         }
       }
@@ -62,7 +60,7 @@ pipeline {
         dir('./charts/preview') {
           container('python') {
             script {
-              PREVIEW_VERSION = readFile "../../PREVIEW_VERSION"
+              PREVIEW_VERSION = readFile("$WORKSPACE/PREVIEW_VERSION").trim()
 
               // create preview namespace if it doesn't exist
               preview_namespace_exists = sh(returnStatus: true, script: "kubectl get namespaces | grep '^$PREVIEW_NAMESPACE[[:space:]]'")
@@ -107,7 +105,7 @@ pipeline {
         }
         container('python') {
           script {
-            VERSION = readFile 'VERSION'
+            VERSION = readFile('VERSION').trim()
             sh """
             export VERSION=$VERSION
             skaffold build -f skaffold.yaml -p prod
@@ -124,12 +122,10 @@ pipeline {
       steps {
         container('python') {
           script {
-            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:${readFile 'VERSION'}".trim()
-            docker
-              .image(repo)
-              .inside {
-                sh "make test"
-            }
+            VERSION = readFile('VERSION').trim()
+            repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$VERSION"
+            // add your env vars as needed with --env-file or -e
+            sh "docker run --rm -t $repo make test"
           }
         }
       }
@@ -142,7 +138,7 @@ pipeline {
         dir('./charts/REPLACE_ME_APP_NAME') {
           container('python') {
             script {
-              VERSION = readFile '../../VERSION'
+              VERSION = readFile("$WORKSPACE/VERSION").trim()
 
               sh "jx step changelog --version v$VERSION"
               // release the helm chart

--- a/packs/python-model-microservice/Jenkinsfile
+++ b/packs/python-model-microservice/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             PREVIEW_VERSION = readFile('PREVIEW_VERSION').trim()
             repo = "$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
             // add your env vars as needed with --env-file or -e
-            sh "docker run --rm -t $repo make test"
+            sh "docker run -e PIP_EXTRA_INDEX_URL=$PIP_EXTRA_INDEX_URL $repo make test"
           }
         }
       }


### PR DESCRIPTION
after a lot of trial and error - using `docker-workflow` from cloudbees with the kubernetes plugin surprisingly works pretty well up until it doesn't then you're wondering WTF is going on.

now it makes sense why upstream uses `sh "docker …"` over the dsl. I'm quite happy using that too now after writing the [dotenv](https://github.com/AmFamLabs/img-svc/blob/8f408b1e459612437fe1c6b5c7812af4da41abfc/Jenkinsfile#L48-L66) in the environment closure ... using this: https://github.com/AmFamLabs/img-svc/blob/8f408b1e459612437fe1c6b5c7812af4da41abfc/Jenkinsfile#L70-L96